### PR TITLE
feat: pixel art face section advancement

### DIFF
--- a/src/models/controlnet_stylizer.py
+++ b/src/models/controlnet_stylizer.py
@@ -4,6 +4,8 @@ import os
 from dataclasses import dataclass, field
 import torch
 from PIL import Image, ImageEnhance
+from controlnet_aux import PidiNetDetector
+from diffusers import ControlNetModel, StableDiffusionControlNetImg2ImgPipeline
 
 os.environ.setdefault("TRANSFORMERS_NO_TF", "1")
 os.environ.setdefault("TRANSFORMERS_NO_FLAX", "1")
@@ -37,13 +39,13 @@ class ControlNetConfig:
     seed: int = 1234
     device: str = "cpu"
     torch_dtype: torch.dtype = field(default=torch.float32)
+    brightness_boost: float = 1.3
+    color_boost: float = 1.3
 
 
 class ControlNetStylizer:
 
     def __init__(self, config: ControlNetConfig) -> None:
-        from controlnet_aux import PidiNetDetector
-        from diffusers import ControlNetModel, StableDiffusionControlNetImg2ImgPipeline
 
         self.config = config
         self._device = self._resolve_device(config.device)
@@ -193,9 +195,9 @@ class ControlNetStylizer:
 
     def apply(self, image: Image.Image) -> Image.Image:
         img = self._resize(image.convert("RGB"))
-        # 입력 전 밝기/채도 보정 (어두운 입력이 어두운 결과로 이어지는 것 방지)
-        img = ImageEnhance.Brightness(img).enhance(1.3)
-        img = ImageEnhance.Color(img).enhance(1.3)
+        # 입력 전 밝기/채도 보정
+        img = ImageEnhance.Brightness(img).enhance(self.config.brightness_boost)
+        img = ImageEnhance.Color(img).enhance(self.config.color_boost)
 
         control_image = self.preprocessor(img, detect_resolution=min(img.size), image_resolution=min(img.size))
         control_image = control_image.resize(img.size, Image.BILINEAR)

--- a/src/models/controlnet_stylizer.py
+++ b/src/models/controlnet_stylizer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 import torch
-from PIL import Image
+from PIL import Image, ImageEnhance
 
 os.environ.setdefault("TRANSFORMERS_NO_TF", "1")
 os.environ.setdefault("TRANSFORMERS_NO_FLAX", "1")
@@ -28,12 +28,12 @@ class ControlNetConfig:
         "faceless, no face, blob face, melted face, "
         "wrong colors, color bleeding, extra colors, unnatural colors"
     )
-    num_inference_steps: int = 35
-    guidance_scale: float = 7.5
-    controlnet_conditioning_scale: float = 0.7
-    strength: float = 0.75
+    num_inference_steps: int = 36
+    guidance_scale: float = 6.0
+    controlnet_conditioning_scale: float = 0.75
+    strength: float = 0.65
     max_size: int = 768
-    lora_scale: float = 0.85
+    lora_scale: float = 0.9
     seed: int = 1234
     device: str = "cpu"
     torch_dtype: torch.dtype = field(default=torch.float32)
@@ -193,6 +193,9 @@ class ControlNetStylizer:
 
     def apply(self, image: Image.Image) -> Image.Image:
         img = self._resize(image.convert("RGB"))
+        # 입력 전 밝기/채도 보정 (어두운 입력이 어두운 결과로 이어지는 것 방지)
+        img = ImageEnhance.Brightness(img).enhance(1.3)
+        img = ImageEnhance.Color(img).enhance(1.3)
 
         control_image = self.preprocessor(img, detect_resolution=min(img.size), image_resolution=min(img.size))
         control_image = control_image.resize(img.size, Image.BILINEAR)

--- a/src/services/api.py
+++ b/src/services/api.py
@@ -38,8 +38,9 @@ _TASKS: set[asyncio.Task] = set()
 _segmenter_lock = threading.Lock()
 _stylizer_lock = threading.Lock()
 _controlnet_lock = threading.Lock()
-
 _VALID_BACKGROUNDS = ("transparent", "white", "original")
+DEFAULT_PIXEL_LONG_EDGE = 192
+DEFAULT_PIXEL_PALETTE = 48
 
 
 def _now_ms() -> int:
@@ -236,8 +237,8 @@ async def pixelate_person(
     file: UploadFile = File(...),
     background: str = Form("white"),
     style: str = Form("character"),
-    long_edge: int = Form(256, ge=32, le=2048),
-    palette: int = Form(64, ge=2, le=256),
+    long_edge: int = Form(DEFAULT_PIXEL_LONG_EDGE, ge=32, le=2048),
+    palette: int = Form(DEFAULT_PIXEL_PALETTE, ge=2, le=256),
 ):
     start = time.time()
 
@@ -274,8 +275,8 @@ async def pixelate_person_async(
     file: UploadFile = File(...),
     background: str = Form("white"),
     style: str = Form("character"),
-    long_edge: int = Form(192, ge=32, le=2048),
-    palette: int = Form(48, ge=2, le=256),
+    long_edge: int = Form(DEFAULT_PIXEL_LONG_EDGE, ge=32, le=2048),
+    palette: int = Form(DEFAULT_PIXEL_PALETTE, ge=2, le=256),
 ):
     if await request.is_disconnected():
         raise HTTPException(status_code=499, detail="client_disconnected")

--- a/src/services/api.py
+++ b/src/services/api.py
@@ -124,8 +124,8 @@ def _pixelate_sync(content: bytes, params: dict[str, Any]) -> tuple[bytes, dict[
 
     background = _normalize_background(str(params.get("background", "white")))
     style = str(params.get("style", "character"))
-    long_edge = int(params.get("long_edge", 192))
-    palette = int(params.get("palette", 48))
+    long_edge = int(params.get("long_edge", DEFAULT_PIXEL_LONG_EDGE))
+    palette = int(params.get("palette", DEFAULT_PIXEL_PALETTE))
     config = PixelArtConfig(target_long_edge=long_edge, palette_size=palette)
 
     if style == "character":
@@ -303,7 +303,7 @@ async def pixelate_person_async(
         for stale_id, stale in list(_JOBS.items()):
             if (
                 stale["status"] in {"SUCCEEDED", "FAILED", "CANCELLED"}
-                and stale.get("update_ms", 0) + JOB_RETENTION_MS <= now
+                and stale.get("updated_ms", 0) + JOB_RETENTION_MS <= now
                 ): 
                     _JOBS.pop(stale_id, None)
         _JOBS[job_id] = job

--- a/src/services/api.py
+++ b/src/services/api.py
@@ -184,52 +184,6 @@ async def _run_pixelate_job(job_id: str, content: bytes, params: dict[str, Any])
                 j["updated_ms"] = _now_ms()
 
 
-@app.post("/pixelate/async")
-async def pixelate_person_async(
-    request: Request,
-    file: UploadFile = File(...),
-    background: str = Form("white"),
-    style: str = Form("character"),
-    long_edge: int = Form(256, ge=32, le=2048),
-    palette: int = Form(64, ge=2, le=256),
-):
-    if await request.is_disconnected():
-        raise HTTPException(status_code=499, detail="client_disconnected")
-
-    try:
-        background = _normalize_background(background)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    content = await file.read()
-    job_id = uuid.uuid4().hex
-    job = {
-        "job_id": job_id,
-        "status": "QUEUED",
-        "created_ms": _now_ms(),
-        "updated_ms": _now_ms(),
-        "cancelled": False,
-        "result_png": None,
-        "error": None,
-        "meta": {},
-    }
-
-    async with _JOBS_LOCK:
-        _JOBS[job_id] = job
-
-    params = {"background": background, "style": style, "long_edge": long_edge, "palette": palette}
-    task = asyncio.create_task(_run_pixelate_job(job_id, content, params))
-    _TASKS.add(task)
-    task.add_done_callback(_TASKS.discard)
-
-    async with _JOBS_LOCK:
-        j = _JOBS.get(job_id)
-        if j is not None:
-            j["task"] = task
-
-    return {"job_id": job_id, "status": "QUEUED"}
-
-
 @app.get("/jobs/{job_id}")
 async def get_job(job_id: str):
     async with _JOBS_LOCK:
@@ -312,3 +266,49 @@ async def pixelate_person(
         media_type="image/png",
         headers={"X-Elapsed-Ms": str(elapsed_ms)},
     )
+
+
+@app.post("/pixelate/async")
+async def pixelate_person_async(
+    request: Request,
+    file: UploadFile = File(...),
+    background: str = Form("white"),
+    style: str = Form("character"),
+    long_edge: int = Form(192, ge=32, le=2048),
+    palette: int = Form(48, ge=2, le=256),
+):
+    if await request.is_disconnected():
+        raise HTTPException(status_code=499, detail="client_disconnected")
+
+    try:
+        background = _normalize_background(background)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    content = await file.read()
+    job_id = uuid.uuid4().hex
+    job = {
+        "job_id": job_id,
+        "status": "QUEUED",
+        "created_ms": _now_ms(),
+        "updated_ms": _now_ms(),
+        "cancelled": False,
+        "result_png": None,
+        "error": None,
+        "meta": {},
+    }
+
+    async with _JOBS_LOCK:
+        _JOBS[job_id] = job
+
+    params = {"background": background, "style": style, "long_edge": long_edge, "palette": palette}
+    task = asyncio.create_task(_run_pixelate_job(job_id, content, params))
+    _TASKS.add(task)
+    task.add_done_callback(_TASKS.discard)
+
+    async with _JOBS_LOCK:
+        j = _JOBS.get(job_id)
+        if j is not None:
+            j["task"] = task
+
+    return {"job_id": job_id, "status": "QUEUED"}

--- a/src/services/api.py
+++ b/src/services/api.py
@@ -34,6 +34,7 @@ _controlnet_stylizer: ControlNetStylizer | None = None
 
 _JOBS: dict[str, dict[str, Any]] = {}
 _JOBS_LOCK = asyncio.Lock()
+JOB_RETENTION_MS = 10 * 60 * 1000
 _TASKS: set[asyncio.Task] = set()
 _segmenter_lock = threading.Lock()
 _stylizer_lock = threading.Lock()
@@ -290,6 +291,7 @@ async def pixelate_person_async(
         "status": "QUEUED",
         "created_ms": _now_ms(),
         "updated_ms": _now_ms(),
+        "expires_ms": _now_ms() + JOB_RETENTION_MS,
         "cancelled": False,
         "result_png": None,
         "error": None,
@@ -297,6 +299,13 @@ async def pixelate_person_async(
     }
 
     async with _JOBS_LOCK:
+        now = _now_ms()
+        for stale_id, stale in list(_JOBS.items()):
+            if (
+                stale["status"] in {"SUCCEEDED", "FAILED", "CANCELLED"}
+                and stale.get("update_ms", 0) + JOB_RETENTION_MS <= now
+                ): 
+                    _JOBS.pop(stale_id, None)
         _JOBS[job_id] = job
 
     task = asyncio.create_task(_run_pixelate_job(job_id, content, params))

--- a/src/services/api.py
+++ b/src/services/api.py
@@ -54,6 +54,22 @@ def _normalize_background(bg: str) -> str:
     return b
 
 
+async def _validate_pixelate_request(
+    request: Request,
+    background: str,
+    style: str,
+    long_edge: int,
+    palette: int,
+) -> dict[str, Any]:
+    if await request.is_disconnected():
+        raise HTTPException(status_code=499, detail="client_disconnected")
+    try:
+        bg = _normalize_background(background)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"background": bg, "style": style, "long_edge": long_edge, "palette": palette}
+
+
 def _job_public(job: dict[str, Any]) -> dict[str, Any]:
     return {
         "job_id": job["job_id"],
@@ -241,22 +257,10 @@ async def pixelate_person(
     palette: int = Form(DEFAULT_PIXEL_PALETTE, ge=2, le=256),
 ):
     start = time.time()
-
-    if await request.is_disconnected():
-        raise HTTPException(status_code=499, detail="client_disconnected")
-
-    try:
-        background = _normalize_background(background)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
+    params = await _validate_pixelate_request(request, background, style, long_edge, palette)
     content = await file.read()
     try:
-        png_bytes, _ = await _run_blocking(
-            _pixelate_sync,
-            content,
-            {"background": background, "style": style, "long_edge": long_edge, "palette": palette}
-        )
+        png_bytes, _ = await _run_blocking(_pixelate_sync, content, params)
     except Exception as exc:
         logger.exception("pixelate sync failed")
         raise HTTPException(status_code=500, detail="pixelate_failed") from exc
@@ -278,14 +282,7 @@ async def pixelate_person_async(
     long_edge: int = Form(DEFAULT_PIXEL_LONG_EDGE, ge=32, le=2048),
     palette: int = Form(DEFAULT_PIXEL_PALETTE, ge=2, le=256),
 ):
-    if await request.is_disconnected():
-        raise HTTPException(status_code=499, detail="client_disconnected")
-
-    try:
-        background = _normalize_background(background)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
+    params = await _validate_pixelate_request(request, background, style, long_edge, palette)
     content = await file.read()
     job_id = uuid.uuid4().hex
     job = {
@@ -302,7 +299,6 @@ async def pixelate_person_async(
     async with _JOBS_LOCK:
         _JOBS[job_id] = job
 
-    params = {"background": background, "style": style, "long_edge": long_edge, "palette": palette}
     task = asyncio.create_task(_run_pixelate_job(job_id, content, params))
     _TASKS.add(task)
     task.add_done_callback(_TASKS.discard)

--- a/src/services/api.py
+++ b/src/services/api.py
@@ -16,14 +16,13 @@ if PROJECT_ROOT not in sys.path:
 
 from src.models.segmentation import PersonSegmenter
 from src.models.cartoon_stylizer import CartoonStylizer, CartoonConfig
-from src.models.anime_stylizer import AnimeStylizer, AnimeConfig
 from src.models.controlnet_stylizer import ControlNetStylizer, ControlNetConfig
 from src.services.pipeline import (
     PixelArtConfig,
     pixel_art_person_cartoon,
-    pixel_art_person_anime,
     pixel_art_person_controlnet,
     resize_mask,
+    keep_largest_component,
 )
 
 app = FastAPI(title="DearLook AI")
@@ -31,7 +30,6 @@ logger = logging.getLogger(__name__)
 
 _segmenter: PersonSegmenter | None = None
 _cartoon_stylizer: CartoonStylizer | None = None
-_anime_stylizer: AnimeStylizer | None = None
 _controlnet_stylizer: ControlNetStylizer | None = None
 
 _JOBS: dict[str, dict[str, Any]] = {}
@@ -39,7 +37,6 @@ _JOBS_LOCK = asyncio.Lock()
 _TASKS: set[asyncio.Task] = set()
 _segmenter_lock = threading.Lock()
 _stylizer_lock = threading.Lock()
-_anime_lock = threading.Lock()
 _controlnet_lock = threading.Lock()
 
 _VALID_BACKGROUNDS = ("transparent", "white", "original")
@@ -100,26 +97,17 @@ def get_controlnet_stylizer() -> ControlNetStylizer:
     return _controlnet_stylizer
 
 
-def get_anime_stylizer() -> AnimeStylizer:
-    global _anime_stylizer
-    with _anime_lock:
-        if _anime_stylizer is None:
-            from src.config.settings import settings
-            device = settings.PIXELART_DEVICE.lower()
-            _anime_stylizer = AnimeStylizer(AnimeConfig(device=device))
-    return _anime_stylizer
-
-
 def _pixelate_sync(content: bytes, params: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:
     image = Image.open(io.BytesIO(content)).convert("RGB")
     segmenter = get_segmenter()
     mask = segmenter.predict_mask(image)
     mask = resize_mask(mask, image.size)
+    mask = keep_largest_component(mask)
 
     background = _normalize_background(str(params.get("background", "white")))
     style = str(params.get("style", "character"))
-    long_edge = int(params.get("long_edge", 256))
-    palette = int(params.get("palette", 64))
+    long_edge = int(params.get("long_edge", 192))
+    palette = int(params.get("palette", 48))
     config = PixelArtConfig(target_long_edge=long_edge, palette_size=palette)
 
     if style == "character":
@@ -128,8 +116,8 @@ def _pixelate_sync(content: bytes, params: dict[str, Any]) -> tuple[bytes, dict[
             image, mask, stylizer,
             background=background,
             pixel_target=long_edge,
-            palette_size=palette
-            )
+            palette_size=palette,
+        )
         mode = "controlnet_pixelart"
     else:
         stylizer = get_cartoon_stylizer()

--- a/src/services/pipeline.py
+++ b/src/services/pipeline.py
@@ -45,6 +45,20 @@ def resize_mask(mask: np.ndarray, size: tuple[int, int]) -> np.ndarray:
     return np.array(pil, dtype=np.float32) / 255.0
 
 
+def keep_largest_component(mask: np.ndarray) -> np.ndarray:
+    """마스크에서 가장 큰 연결 영역만 남기고 나머지 작은 조각을 제거합니다."""
+    from scipy.ndimage import label
+    binary = mask > 0.5
+    labeled, num_features = label(binary)
+    if num_features <= 1:
+        return mask
+    sizes = np.bincount(labeled.ravel())
+    sizes[0] = 0  # background
+    largest = sizes.argmax()
+    result = np.where(labeled == largest, mask, 0.0)
+    return result.astype(np.float32)
+
+
 def apply_alpha(image: Image.Image, mask: np.ndarray) -> Image.Image:
     rgba = image.convert("RGBA")
     alpha = (np.clip(mask, 0.0, 1.0) * 255).astype(np.uint8)
@@ -151,7 +165,8 @@ def _person_pipeline(
     pixelize_fn: Callable[[Image.Image], Image.Image],
 ) -> Image.Image:
     """공통 파이프라인: dilation → bbox crop → 흰 배경 합성 → stylize → pixelize → alpha 합성 → canvas."""
-    binary = mask >= mask_threshold
+    binary_orig = mask >= mask_threshold  # alpha에 사용할 원본 마스크
+    binary = binary_orig.copy()
     if mask_dilate_px > 0:
         struct = np.ones((mask_dilate_px * 2 + 1, mask_dilate_px * 2 + 1), dtype=bool)
         binary = binary_dilation(binary, structure=struct)
@@ -159,7 +174,8 @@ def _person_pipeline(
     w, h = image.size
     x0, y0, x1, y1 = _mask_to_bbox(binary, threshold=mask_threshold)
     crop_img = image.crop((x0, y0, x1, y1)).convert("RGB")
-    m_crop = binary[y0:y1, x0:x1]
+    m_crop = binary[y0:y1, x0:x1]           # dilation 마스크 (crop/stylize용)
+    m_alpha = binary_orig[y0:y1, x0:x1]     # 원본 마스크 (alpha 합성용)
 
     bg = Image.new("RGB", crop_img.size, fill_color)
     mask_pil = Image.fromarray((m_crop * 255).astype(np.uint8), mode="L")
@@ -167,17 +183,35 @@ def _person_pipeline(
 
     styled = stylize_fn(bg)
     pixeled = pixelize_fn(styled)
-    styled_masked = apply_alpha(pixeled, m_crop.astype(np.float32))
+    styled_masked = apply_alpha(pixeled, m_alpha.astype(np.float32))
 
     if background == "original":
         canvas = image.convert("RGBA")
         canvas.paste(styled_masked, (x0, y0), styled_masked)
+        return canvas
     else:
-        canvas_color = (255, 255, 255, 255) if background == "white" else (0, 0, 0, 0)
-        canvas = Image.new("RGBA", (w, h), canvas_color)
-        canvas.paste(styled_masked, (x0, y0), styled_masked)
+        # 알파 픽셀 기준으로 실제 캐릭터 범위를 구해 가운데 배치
+        alpha = np.array(styled_masked.split()[3])
+        ys_a, xs_a = np.where(alpha > 10)
+        if xs_a.size > 0:
+            ax0, ax1 = int(xs_a.min()), int(xs_a.max())
+        else:
+            ax0, ax1 = 0, styled_masked.width
 
-    return canvas
+        cw, ch = styled_masked.size
+        char_w = ax1 - ax0 + 1
+        pad_h = int(char_w * 0.12)
+        pad_v = int(ch * 0.05)
+
+        canvas_w = char_w + pad_h * 2
+        canvas_h = ch + pad_v * 2
+        canvas_color = (255, 255, 255, 255) if background == "white" else (0, 0, 0, 0)
+        canvas = Image.new("RGBA", (canvas_w, canvas_h), canvas_color)
+        # 캐릭터 bbox의 ax0을 기준으로 pad_h만큼 왼쪽에 배치 → 좌우 대칭
+        paste_x = pad_h - ax0
+        paste_y = pad_v
+        canvas.paste(styled_masked, (paste_x, paste_y), styled_masked)
+        return canvas
 
 
 def _color_transfer(source: Image.Image, target: Image.Image) -> Image.Image:
@@ -252,40 +286,49 @@ def pixel_art_person_controlnet(
         return stylizer.apply(img)
 
     def pixelize_with_orig_palette(styled: Image.Image) -> Image.Image:
+        import colorsys
         orig = captured_original[0] if captured_original else styled
         orig_resized = orig.resize(styled.size, Image.BILINEAR).convert("RGB")
 
-        # 원본 이미지에서 팔레트 추출
-        q = orig_resized.quantize(colors=config.palette_size, method=Image.Quantize.MEDIANCUT)
+        # 팔레트 추출 전 median blur로 잡색 제거
+        palette_src = orig_resized.filter(__import__("PIL.ImageFilter", fromlist=["MedianFilter"]).MedianFilter(size=3))
+        q = palette_src.quantize(colors=config.palette_size, method=Image.Quantize.MEDIANCUT, dither=Image.Dither.NONE)
         raw = q.getpalette()
         orig_palette = np.array(raw[:config.palette_size * 3]).reshape(-1, 3).astype(np.float32)
 
-        # HSV 기반 팔레트 보정: 색조 유지 + 채도 강화 + 어두운 색만 밝기 보정
-        import colorsys
+        # HSV 기반 팔레트 보정: 채도 강화 + 밝기 보정
         boosted = []
         for color in orig_palette:
             r, g, b = color / 255.0
             h, s, v = colorsys.rgb_to_hsv(r, g, b)
-            s = min(1.0, s * 2.2)       # 채도 강화
-            v = min(1.0, v * 1.4 + 0.08) if v < 0.5 else min(1.0, v * 1.1)  # 어두운 색만 밝기 보정
+            s = min(1.0, s * 2.0)
+            v = min(1.0, v * 1.3 + 0.06) if v < 0.5 else min(1.0, v * 1.08)
             r2, g2, b2 = colorsys.hsv_to_rgb(h, s, v)
             boosted.append([r2 * 255, g2 * 255, b2 * 255])
         orig_palette = np.array(boosted, dtype=np.float32)
 
-        # styled 이미지를 pixeloe로 픽셀화
+        # pixeloe 픽셀화 (downscale → palette → nearest upscale 순서)
         pixelized = _pixel_art_pixeloe(styled, config).convert("RGB")
 
         pix_arr = np.array(pixelized).astype(np.float32)
         h, w = pix_arr.shape[:2]
         flat = pix_arr.reshape(-1, 3)
 
-        # 각 픽셀 → 원본 팔레트 최근접 색 매핑
+        # 원본 팔레트 최근접 색 매핑 (디더링 없음)
         dists = np.sum((flat[:, None, :] - orig_palette[None, :, :]) ** 2, axis=2)
         nearest = np.argmin(dists, axis=1)
         remapped = orig_palette[nearest].reshape(h, w, 3).clip(0, 255).astype(np.uint8)
 
         result = Image.fromarray(remapped)
-        result = ImageEnhance.Color(result).enhance(1.2)
+        result = ImageEnhance.Color(result).enhance(1.15)
+
+        # 엣지 오버레이: 윤곽선 강화
+        result_arr = np.array(result).astype(np.float32)
+        edges = _edge_map(result_arr.astype(np.uint8), threshold=0.06)
+        blend = 0.85  # 엣지 위치에 어두운 색을 85% 블렌딩
+        result_arr[edges] = result_arr[edges] * (1 - blend) + np.array([15, 15, 15]) * blend
+        result = Image.fromarray(result_arr.clip(0, 255).astype(np.uint8))
+
         return result.convert("RGBA")
 
     return _person_pipeline(
@@ -353,3 +396,5 @@ def pixel_art_person_cartoon(
         stylize_fn=stylizer.apply,
         pixelize_fn=lambda img: _pixel_art(img, config),
     )
+
+

--- a/src/services/pipeline.py
+++ b/src/services/pipeline.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable
 
 import numpy as np
-from PIL import Image, ImageEnhance
+from PIL import Image, ImageEnhance, ImageFilter
 from scipy.ndimage import binary_dilation
 
 import torch
@@ -45,10 +45,9 @@ def resize_mask(mask: np.ndarray, size: tuple[int, int]) -> np.ndarray:
     return np.array(pil, dtype=np.float32) / 255.0
 
 
-def keep_largest_component(mask: np.ndarray) -> np.ndarray:
-    """마스크에서 가장 큰 연결 영역만 남기고 나머지 작은 조각을 제거합니다."""
+def keep_largest_component(mask: np.ndarray, threshold: float = 0.5) -> np.ndarray:
     from scipy.ndimage import label
-    binary = mask > 0.5
+    binary = mask > threshold
     labeled, num_features = label(binary)
     if num_features <= 1:
         return mask
@@ -85,7 +84,6 @@ def _mask_to_bbox(
     pad: int = 6,
     bottom_pad: int = 20,
 ) -> tuple[int, int, int, int]:
-    """bbox 추출. bottom_pad를 더 크게 주어 신발 등 하단 악세사리를 포함."""
     h, w = mask.shape
     ys, xs = np.where(mask >= threshold)
     if xs.size == 0 or ys.size == 0:
@@ -127,12 +125,10 @@ def _pixel_art(image: Image.Image, config: PixelArtConfig) -> Image.Image:
 
 
 def _pixel_art_pixeloe(image: Image.Image, config: PixelArtConfig) -> Image.Image:
-    """pixeloe 기반 픽셀아트 변환 — 엣지 인식, 깔끔한 캐릭터 스프라이트 스타일."""
     original_size = image.size
     w, h = original_size
     pixel_size = max(4, max(w, h) // config.target_long_edge)
 
-    # pixeloe 내부 다운스케일(pixel_size) 후 wavelet radius(32) 보장
     min_w = pixel_size * 64
     min_h = pixel_size * 64
     if w < min_w or h < min_h:
@@ -164,7 +160,6 @@ def _person_pipeline(
     stylize_fn: Callable[[Image.Image], Image.Image],
     pixelize_fn: Callable[[Image.Image], Image.Image],
 ) -> Image.Image:
-    """공통 파이프라인: dilation → bbox crop → 흰 배경 합성 → stylize → pixelize → alpha 합성 → canvas."""
     binary_orig = mask >= mask_threshold  # alpha에 사용할 원본 마스크
     binary = binary_orig.copy()
     if mask_dilate_px > 0:
@@ -215,7 +210,6 @@ def _person_pipeline(
 
 
 def _color_transfer(source: Image.Image, target: Image.Image) -> Image.Image:
-    """원본(source) 색감을 타겟(target)에 이식 (LAB 통계 전이)."""
     src = np.array(source.convert("RGB")).astype(np.float32)
     tgt = np.array(target.convert("RGB")).astype(np.float32)
 
@@ -276,7 +270,6 @@ def pixel_art_person_controlnet(
     pixel_target: int = 128,
     palette_size: int = 32,
 ) -> Image.Image:
-    """ControlNet + SD1.5 + LoRA 픽셀아트 변환 후 pixeloe 마무리."""
     config = PixelArtConfig(target_long_edge=pixel_target, palette_size=palette_size)
 
     captured_original: list[Image.Image] = []
@@ -291,7 +284,7 @@ def pixel_art_person_controlnet(
         orig_resized = orig.resize(styled.size, Image.BILINEAR).convert("RGB")
 
         # 팔레트 추출 전 median blur로 잡색 제거
-        palette_src = orig_resized.filter(__import__("PIL.ImageFilter", fromlist=["MedianFilter"]).MedianFilter(size=3))
+        palette_src = orig_resized.filter(ImageFilter.MedianFilter(size=3))
         q = palette_src.quantize(colors=config.palette_size, method=Image.Quantize.MEDIANCUT, dither=Image.Dither.NONE)
         raw = q.getpalette()
         orig_palette = np.array(raw[:config.palette_size * 3]).reshape(-1, 3).astype(np.float32)
@@ -350,7 +343,6 @@ def pixel_art_person_anime(
     background: str = "white",
     mask_dilate_px: int = 4,
 ) -> Image.Image:
-    """AnimeGAN2 일러스트 변환 → pixeloe 픽셀아트."""
     if config is None:
         config = ANIME_PIXELART_DEFAULTS
 
@@ -384,7 +376,6 @@ def pixel_art_person_cartoon(
     background: str = "white",
     mask_dilate_px: int = 12,
 ) -> Image.Image:
-    """mask_dilate_px: 마스크 팽창 반경(픽셀). 핸드폰·가방·신발 등 인물 인접 악세사리 포함."""
     if config is None:
         config = PixelArtConfig()
     return _person_pipeline(


### PR DESCRIPTION
## 관련 이슈

Open #8 

## 🎯 배경

- 픽셀아트 변경 시 얼굴 부분이 뭉게지는 현상이 발생하였습니다.

## 🔍 주요 내용

- [x] ControlNet 적용
- [x] Character LoRA 변경(pixel_art_style_v3)
- [x] 밝기/채도 상승
- [x] 이미지 스타일 edge/palette 고정(192,48)
- [x] threshold(윤곽선) 강조

## 결과
<img width="366" height="936" alt="image" src="https://github.com/user-attachments/assets/213b30df-a693-44fc-a234-adccdc167c78" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 요약
픽셀아트 얼굴 디테일이 뭉개지는 문제를 해결하기 위해 ControlNet 기반 제어, 캐릭터 LoRA 교체, 마스크·팔레트 후처리, 밝기·채도 보정 및 엣지 강조를 종합 적용했습니다. 비즈니스적으로는 픽셀 캐릭터 품질 개선으로 에셋 재작업 비용과 반복 수정 빈도를 줄이는 것이 목표입니다.

## 주요 변경점
- ControlNet 파이프라인 적용 및 하이퍼파라미터 조정: num_inference_steps 35→36, guidance_scale 7.5→6.0, controlnet_conditioning_scale 0.7→0.75, strength 0.75→0.65, lora_scale 0.85→0.9
- Character LoRA 교체: pixel_art_style_v3 적용
- 입력 전처리 보정 추가: ControlNet 전처리에 brightness_boost, color_boost 기본값 1.3 도입(이미지 리사이즈 후 밝기·채도 향상)
- API/엔드포인트 정리 및 기본값 변경: pixelate 기본 long_edge 256→192, palette 64→48로 축소(동기/비동기 핸들러 공통 검증 함수 도입)
- 마스크 처리 개선: resize_mask 이후 keep_largest_component 적용, alpha 합성용 원본 마스크(binary_orig)와 스타일화용 dilated 마스크(binary) 분리
- 팔레트 추출·후처리 개선: median filter 적용, 양자화(dither) 비활성화, HSV 기반 채도·명도 보정, Color enhance 1.2→1.15로 미세 조정
- 엣지 오버레이 추가: _edge_map(threshold=0.06)로 윤곽 검출 후 RGB(15,15,15) 방향으로 85% 블렌드해 픽셀 경계 강화
- 코드 정리: AnimeStylizer 관련 경로 제거 및 pixelate 요청 처리 중복 제거, 공통 검증 함수 도입으로 제어 흐름 단순화

## 잘한 점 👍
- 합성용 마스크와 스타일화용 마스크를 분리해 스타일화 과정이 합성 품질을 해치지 않도록 한 점이 설계상 적절합니다.
- median filter·keep_largest_component 적용으로 노이즈·작은 컴포넌트 영향을 줄여 실무에 적합한 전처리 파이프라인을 구성한 점이 좋습니다.
- 엣지 강화 처리를 명확한 후처리 단계로 분리해 튜닝과 유지보수가 용이하도록 한 점이 긍정적입니다.

## 리스크 / 주의사항 ⚠️
- 연결성 분석(labeling) 관련 함수(scipy.ndimage 등) 및 버전 요구사항이 존재하면 requirements에 반영 필요.
- ControlNet·LoRA·하이퍼파라미터 변경은 결과 재현성에 영향 — 시드·모델 버전 명시와 비교 실험 필요.
- 엣지 threshold(0.06), blend factor(0.85), brightness/color boost(1.3) 등 하드코딩 값은 조명·해상도에 따라 과·미세 조정 유발 — 파라미터화 또는 환경별 프로파일 권장.
- 기본 long_edge 축소(256→192)는 처리 비용 절감 효과가 있으나 고해상도 디테일 손실 우려가 있어 케이스별 영향 검증 필요.
- AnimeStylizer 제거는 기존 통합 흐름에 영향 가능 — 사용자 영향 범위 점검 및 필요시 호환성 대응 필요.

## 다음 액션 📌
- 다양한 얼굴 유형(연령·인종), 조명, 해상도에 대한 시각적 회귀 테스트 및 정량 평가(LPIPS 등) 수행
- requirements.txt 및 배포 문서에 새 의존성·하이퍼파라미터·기본값 변경 명시
- 엣지·팔레트·전처리 부스트 파라미터를 런타임에서 조정 가능하도록 설정(환경 변수/API 파라미터) 검토
- AnimeStylizer 제거의 영향 범위 조사 및 필요 시 사용자 공지 또는 역호환 대응 마련
<!-- end of auto-generated comment: release notes by coderabbit.ai -->